### PR TITLE
outline-color

### DIFF
--- a/ethereal.css
+++ b/ethereal.css
@@ -22,6 +22,7 @@
 
 :any-link {
   color: #50a;
+  outline-color: #50a;
 }
 
 mark {


### PR DESCRIPTION
`outline-color` was appearing like mist in chrome
